### PR TITLE
Fixed naming inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Multi-module implementation is possible, see ``xlogin42`` for an example.
 
 ## Learning about the world
 Board's ``get_player_areas()``, ``get_player_border()``, and ``get_players_regions()`` can be used to discover areas belonging to any player in the game.
-Instances of ``Area`` then allow further inquiry through ``get_adjacent_areas()``, ``get_owner_name()`` and ``get_dice()``.
+Instances of ``Area`` then allow further inquiry through ``get_adjacent_areas_names()``, ``get_owner_name()`` and ``get_dice()``.
 
 It may also be practical to acquire all possible moves from ``dicewars.ai.utils.possible_attacks()``.
 This module also provides formulas for probability of conquering and holding an Area.

--- a/dicewars/ai/dt/wpm_c.py
+++ b/dicewars/ai/dt/wpm_c.py
@@ -144,7 +144,7 @@ class AI:
             if area_name in self.largest_region:
                 increase_score = True
             else:
-                for n in target.get_adjacent_areas():
+                for n in target.get_adjacent_areas_names():
                     if n in self.largest_region:
                         increase_score = True
                         break

--- a/dicewars/ai/dt/wpm_d.py
+++ b/dicewars/ai/dt/wpm_d.py
@@ -118,7 +118,7 @@ class AI:
             if area_name in self.largest_region:
                 increase_score = True
             else:
-                for n in target.get_adjacent_areas():
+                for n in target.get_adjacent_areas_names():
                     if n in self.largest_region:
                         increase_score = True
                         break

--- a/dicewars/ai/dt/wpm_s.py
+++ b/dicewars/ai/dt/wpm_s.py
@@ -96,7 +96,7 @@ class AI:
             if area_name in self.largest_region:
                 increase_score = True
             else:
-                for n in target.get_adjacent_areas():
+                for n in target.get_adjacent_areas_names():
                     if n in self.largest_region:
                         increase_score = True
                         break

--- a/dicewars/ai/kb/sdc_at.py
+++ b/dicewars/ai/kb/sdc_at.py
@@ -60,7 +60,7 @@ class AI:
                     if area.get_dice() < 2:
                         continue
 
-                    for neigh in area.get_adjacent_areas():
+                    for neigh in area.get_adjacent_areas_names():
                         if neigh in border_names and board.get_area(neigh).get_dice() < 8:
                             return TransferCommand(area.get_name(), neigh)
             else:

--- a/dicewars/ai/utils.py
+++ b/dicewars/ai/utils.py
@@ -39,7 +39,7 @@ def probability_of_holding_area(board, area_name, area_dice, player_name):
     """
     area = board.get_area(area_name)
     probability = 1.0
-    for adj in area.get_adjacent_areas():
+    for adj in area.get_adjacent_areas_names():
         adjacent_area = board.get_area(adj)
         if adjacent_area.get_owner_name() != player_name:
             enemy_dice = adjacent_area.get_dice()
@@ -165,7 +165,7 @@ def possible_attacks(board: Board, player_name: int) -> Iterator[Tuple[Area, Are
         if not area.can_attack():
             continue
 
-        neighbours = area.get_adjacent_areas()
+        neighbours = area.get_adjacent_areas_names()
 
         for adj in neighbours:
             adjacent_area = board.get_area(adj)

--- a/dicewars/client/ai_driver.py
+++ b/dicewars/client/ai_driver.py
@@ -247,7 +247,7 @@ class AIDriver:
             self.ai_disabled = True
             return False
 
-        if battle.target_name not in source_area.get_adjacent_areas():
+        if battle.target_name not in source_area.get_adjacent_areas_names():
             self.logger.error('Attempted to attack from area {} area {} which is not adjacent.'.format(
                 battle.source_name, battle.target_name
             ))
@@ -292,7 +292,7 @@ class AIDriver:
             self.ai_disabled = True
             return False
 
-        if transfer.target_name not in source_area.get_adjacent_areas():
+        if transfer.target_name not in source_area.get_adjacent_areas_names():
             self.logger.error('Attempted to transfer from area {} to area {} which is not adjacent.'.format(
                 transfer.source_name, transfer.target_name
             ))

--- a/dicewars/client/game/area.py
+++ b/dicewars/client/game/area.py
@@ -22,7 +22,7 @@ class Area:
         self.neighbours = [int(n) for n in neighbours]
         self.hexes = [[int(i) for i in h] for h in hexes]
 
-    def get_adjacent_areas(self) -> List[int]:
+    def get_adjacent_areas_names(self) -> List[int]:
         """Return names of adjacent areas
         """
         return self.neighbours

--- a/dicewars/client/game/board.py
+++ b/dicewars/client/game/board.py
@@ -77,7 +77,7 @@ class Board:
 
             current_region.append(current_area)
 
-            for neighbour_name in self.get_area(current_area).get_adjacent_areas():
+            for neighbour_name in self.get_area(current_area).get_adjacent_areas_names():
                 if neighbour_name in current_region:
                     continue
                 if neighbour_name in current_region:
@@ -90,7 +90,7 @@ class Board:
 
     def is_at_border(self, area: Area) -> bool:
         owner = area.get_owner_name()
-        neighbourhood_names = area.get_adjacent_areas()
+        neighbourhood_names = area.get_adjacent_areas_names()
 
         for neighbour_name in neighbourhood_names:
             neighbour = self.get_area(neighbour_name)

--- a/dicewars/client/ui.py
+++ b/dicewars/client/ui.py
@@ -133,7 +133,7 @@ class MainWindow(QWidget):
                 if area.get_name() == self.activated_area_name:
                     self.deactivate_area()
                     self.update()
-                elif area.get_name() in self.activated_area.get_adjacent_areas():
+                elif area.get_name() in self.activated_area.get_adjacent_areas_names():
                     if area.get_owner_name() != self.game.current_player.get_name():
                         self.game.send_message('battle', self.activated_area_name, area.get_name())
                     else:

--- a/scripts/visual-debugger.py
+++ b/scripts/visual-debugger.py
@@ -15,7 +15,7 @@ class DetailedAreaReporter:
         self.board = board
 
     def __call__(self, area):
-        neighbours = [self.board.get_area(a) for a in area.get_adjacent_areas()]
+        neighbours = [self.board.get_area(a) for a in area.get_adjacent_areas_names()]
         enemy_neighbours = [a for a in neighbours if a.get_owner_name() != area.get_owner_name()]
         return '{}: {} -- {}\n'.format(
             area.get_name(),


### PR DESCRIPTION
Renamed function `get_adjacent_areas` to `get_adjacent_areas_names` in client.game.Area.
The current name `get_adjacent_areas` implies that the function returns instances of the Area class, which is not the case. Instead, it returns names of those areas. Furthermore, there is an inconsistency in naming with a function of the same functionality---the inconsistency is between server.Area and client.game.Area. The former provides two methods--- `get_adjacent_areas` and  `get_adjacent_areas_names`. `get_adjacent_areas` returns the actual objects, whereas  `get_adjacent_areas_names` returns names of those areas. 

After this change, code that is intended to work with whichever area no longer needs to differentiate between the two area classes.